### PR TITLE
fix: support authors with space in name

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -38,8 +38,11 @@ function getAuthors(): Promise<
             const parts = line.split(/[\t\s]+/)
             return {
               commits: parseInt(parts[0], 10),
-              name: parts[1],
-              email: parts[2].substr(1, parts[2].length - 2),
+              name: parts.slice(1, parts.length - 1).join(' '),
+              email: parts[parts.length - 1].substring(
+                1,
+                parts[parts.length - 1].length - 1,
+              ),
             }
           })
         resolve(authors)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Currently if an author has a space in his display name, the action will output a wrong email as it splits the git shortlog by space and then interprets the second part of the authors name as email.
With this fix all parts in the splitted git shortlog array between the number of commits and the email will be concatinated to the users name.   
In addition the deprecated substr() function was replaced with substring().
### Motivation and Context
I noticed in a project which uses this action that the email of some users was wrongly inserted into the AUTHORS file.  
I investigated the issue and found out that it was due to a bug in this action.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to change)
- [ ] **Enhancement** (changes that improvement of current feature or performance)
- [ ] **Refactoring** (changes that neither fixes a bug nor adds a feature)
- [ ] **Test Case** (changes that add missing tests or correct existing tests)
- [ ] **Code style optimization** (changes that do not affect the meaning of the code)
- [ ] **Docs** (changes that only update documentation)
- [ ] **Chore** (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.